### PR TITLE
Fix config filename in the launch file

### DIFF
--- a/launch/teleop_omnigrasper.launch
+++ b/launch/teleop_omnigrasper.launch
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="joy_config" default="logitech-holonomic" />
+  <arg name="joy_config" default="logitech_holonomic" />
   <arg name="joy_dev" default="/dev/input/js0" />
   
   <node pkg="joy" type="joy_node" name="joy_node">


### PR DESCRIPTION
At [this commit](https://github.com/resibots/teleop_youbot/commit/56936847bad8e1ece238c273e6660fcaad26602f), the name of the config file is modified from `logitech-holonomic.config.yaml` to `logitech_holonomic.config.yaml` , but the name in the launch file is still previous one.
This PR fixes it.